### PR TITLE
 Error en despliegue sobre navbar #22 

### DIFF
--- a/src/app/home/components/Navbar.tsx
+++ b/src/app/home/components/Navbar.tsx
@@ -15,7 +15,7 @@ export const Navbar: React.FC = () => {
 
   return (
     <header className='font-DM sticky top-0 z-50 border-b-2 border-gray-200 bg-black-3'>
-      <div className='mx-auto px-4 py-2 lg:flex lg:items-center justify-between'>
+      <div className='mx-auto justify-between px-4 py-2 lg:flex lg:items-center'>
         <div className='scroll flex justify-between lg:justify-start'>
           <a href='#' className='flex flex-row justify-start'>
             <img
@@ -55,7 +55,7 @@ export const Navbar: React.FC = () => {
         </div>
 
         {/* Enlace de navegación visible en pantallas medianas y grandes */}
-        <nav className='space-x-10 z-10 hidden lg:flex lg:w-auto'>
+        <nav className='z-10 hidden space-x-10 lg:flex lg:w-auto'>
           <Navlist />
         </nav>
 


### PR DESCRIPTION
## Feature o Ticket

[Ticket #22 ](https://github.com/ScrumLatamCommunity/web-portal/issues/22#issue-2629233650)

## Descripción del problema
En el despliegue de la aplicación, se muestran errores de prettier relacionados con el orden de las clases en los componentes Navbar.tsx.

## Pasos para reproducir
1. Desplegar la aplicación en el entorno de producción.
2. Navegar a las páginas que contienen el componente Navbar.
3. Observar los errores en los registros de despliegue.

## Errores específicos
- **Navbar.tsx - Línea 18**  
  Error: Replace 'px-4 py-2 lg:flex lg:items-center justify-between' with 'justify-between px-4 py-2 lg:flex lg:items-center'.  
  Sugerencia: Reorganizar el orden de las clases en el `className`.

- **Navbar.tsx - Línea 58**  
  Error: Replace 'z-10 hidden space-x-10' with 'space-x-10 z-10 hidden'.  
  Sugerencia: Reorganizar el orden de las clases para cumplir con las reglas de prettier.

## Resultado esperado
El Navbar debería cumplir con las reglas de prettier sin mostrar errores de formato en el despliegue.

## Resultado actual
Aparecen errores de prettier en el despliegue, lo que puede afectar la calidad del código en producción.

## Cambios realizados
- Se reorganizaron las clases en el archivo `Navbar.tsx` en las líneas 18 y 58 para cumplir con las reglas de prettier.

## Notas adicionales
- Se recomienda verificar el despliegue nuevamente después de realizar estos cambios para asegurarse de que no aparezcan errores relacionados con prettier.
