### PR TITLE
fix: location and sizes of text and images, desktop and mobile version

### DIFF
--- a/src/app/home/components/WelcomeToCommunity.tsx
+++ b/src/app/home/components/WelcomeToCommunity.tsx
@@ -6,6 +6,7 @@ import useIsLargeScreen from '@/hooks/index'
 
 export const WelcomeToCommunity = () => {
   const isLargeScreen = useIsLargeScreen(468)
+  console.log('Hook value:', isLargeScreen)
   const [image, setImage] = useState(image_url_mobile)
 
   useEffect(() => {
@@ -18,13 +19,15 @@ export const WelcomeToCommunity = () => {
         <div className='absolute right-0 top-10 h-[100px] w-[100px] rounded-full bg-blue-5 opacity-60 blur-2xl md:hidden'></div>
         <div className='absolute -left-14 bottom-1/4 h-[300px] w-[300px] rounded-full bg-red-300 opacity-20 blur-2xl md:hidden'></div>
         <div className='max-w-screen-2xl font-darker-grotesque md:w-1/2 md:pl-16 xl:pl-40'>
-          <h1 className='max-w-prose text-15 font-darker-grotesque-4 leading-1 text-red-500 md:text-14 xl:text-19'>
+          <h1
+            className={`max-w-prose text-15 font-darker-grotesque-4 leading-1 text-red-500 md:text-14 xl:text-19 ${isLargeScreen ? '' : 'mt-4'}`}
+          >
             ¡Bienvenido!
           </h1>
           <h2 className='text-12 font-extrabold leading-8 opacity-80 md:w-11/12 md:text-11 md:leading-[30px] xl:w-11/12 xl:text-17 xl:leading-1'>
             a Scrum Latam: Donde la Comunidad y la Agilidad Convergen
           </h2>
-          <p className='w-[86%] pt-6 font-karla text-5 font-semibold leading-[21.6px] text-blue-8 md:w-[100%] md:text-4 md:leading-[23.23px] xl:w-[85.1%] xl:text-10 xl:leading-8'>
+          <p className='w-[86%] pt-6 font-karla text-5 font-semibold leading-[21.6px] text-blue-8 md:w-[100%] md:text-4 md:leading-[23.23px] xl:w-[80%] xl:text-10 xl:leading-8'>
             Nos dedicamos al aprendizaje colaborativo y a la implementación de
             metodologías ágiles. ¡Bienvenidos a un entorno donde la cooperación
             y la agilidad impulsan nuestro crecimiento y éxito!
@@ -35,7 +38,9 @@ export const WelcomeToCommunity = () => {
         </div>
         <img
           alt='Landscape picture'
-          className='aspect-[693/662] w-1/2'
+          className={`-mt-4 aspect-[693/662] ${
+            isLargeScreen ? 'w-[45%] -translate-x-10' : 'w-[85%] -translate-x-1'
+          } -translate-y-8`}
           src={image}
         />
       </div>


### PR DESCRIPTION
## Feature o Ticket

- Jira Link: [PWS1-70](https://scrumlatamc.atlassian.net/browse/PWS1-70)

## Descripción

Breve descripción: Se ajusto el tamaño del texto debajo del título, mas precisamente la última línea para que se lea "y éxito!". La ilustración a la derecha se subió un poco y se redujo su tamaño. Para la versión desktop. 
Se agrando la ilustración y se coloco un poco más a la derecha, además se agrego espacio entre el navbar y el título de bienvenido. 

Detalles:

- Se actualizaron los estilos en los classname con Tailwinds que corresponden al Bienvenido para agregar espacio adicional en la vista Mobile.
- Se actualizaron los estilos en los classname con Tailwinds que corresponden a la imagen para aumentar su tamaño en la vista Mobile.
- Se actualizaron los estilos en los classname con Tailwinds  que corresponden a la imagen para reducirla, subirla y colocarla mas a la izquierda en la vista Desktop. 
- Se actualizaron los estilos en los classname con Tailwinds que corresponden al texto para que sea como en el figma, en 6 filas y con el éxito! al final (Ambas vistas).

## ¿Cómo se ha probado esto?

Se realizaron pruebas en las siguientes vistas para asegurar que los cambios funcionen correctamente:

- Vista A: Mobile 
  - Test A1: Chrome vista Iphone XR
  - Test A2: Mozilla vista Galaxy S20+
- Vista B: Desktop
  - Test B1: Chrome Pantalla de 1920 x 1080
  - Test B2: Mozilla Pantalla de 1920 x 1080
  - Test  B3: Edge Pantalla de 1920 x 1080 

### Pasos para reproducir:

1. Navegar a la vista del inicio

### Notas adicionales:

La vista Mobile no funciona en este momento. 
