### PR TITLE
Fix cifras espacios

### DIFF
--- a/src/app/home/components/CounterToCommunity.tsx
+++ b/src/app/home/components/CounterToCommunity.tsx
@@ -7,7 +7,7 @@ const gea_icon =
 export const CounterToCommunity = () => {
   useCounter(counters)
   return (
-    <section className='relative m-auto mt-8 max-w-screen-2xl font-darker-grotesque'>
+    <section className='relative m-auto mt-8 max-w-screen-2xl pb-16 font-darker-grotesque'>
       <div className='absolute right-44 top-0 z-10 hidden h-[19dvw] w-[19dvw] rounded-full bg-red-300 opacity-15 blur-3xl md:block'></div>
       <div className='absolute bottom-1/4 left-40 z-10 hidden h-[19dvw] w-[19dvw] rounded-full bg-blue-5 opacity-15 blur-3xl md:block'></div>
       <div className='mt-8 flex flex-wrap items-center justify-center gap-4 pt-12'>

--- a/src/app/home/components/Reviews.tsx
+++ b/src/app/home/components/Reviews.tsx
@@ -66,7 +66,7 @@ export const Reviews: React.FC = () => {
     <div
       className={`flex flex-col gap-7 ${fullReviews ? 'bg-gray-200' : ''} ${fullReviews && isMobile ? 'bg-black-1' : ''}`}
     >
-      <span className='pb-10 pt-14 text-center font-darker-grotesque text-[20px] font-extrabold text-blue-6 sm:text-3xl md:text-5xl'>
+      <span className='pb-10 pt-10 text-center font-darker-grotesque text-[20px] font-extrabold text-blue-6 sm:text-3xl md:text-5xl'>
         ¿Qué opina nuestra comunidad?
       </span>
       <div

--- a/src/app/home/components/Reviews.tsx
+++ b/src/app/home/components/Reviews.tsx
@@ -66,7 +66,7 @@ export const Reviews: React.FC = () => {
     <div
       className={`flex flex-col gap-7 ${fullReviews ? 'bg-gray-200' : ''} ${fullReviews && isMobile ? 'bg-black-1' : ''}`}
     >
-      <span className='text-center font-darker-grotesque text-[20px] font-extrabold text-blue-6 sm:text-3xl md:text-5xl'>
+      <span className='pb-10 pt-14 text-center font-darker-grotesque text-[20px] font-extrabold text-blue-6 sm:text-3xl md:text-5xl'>
         ¿Qué opina nuestra comunidad?
       </span>
       <div

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -232,13 +232,13 @@ export const counters: Counter[] = [
   },
   {
     id: 2,
-    number: 20,
+    number: 19,
     text: 'Países',
     icon: 'https://firebasestorage.googleapis.com/v0/b/scrum-latam-imgs.appspot.com/o/Counters%20icons%2FPaises%20icon.svg?alt=media&token=5768415a-6508-411c-849c-6ce59b0eccf7',
   },
   {
     id: 3,
-    number: 162,
+    number: 165,
     text: 'Webinars',
     icon: 'https://firebasestorage.googleapis.com/v0/b/scrum-latam-imgs.appspot.com/o/Counters%20icons%2FWebinar%20icon.svg?alt=media&token=2ed101e1-382c-49d8-8f43-fd00fe3492b8',
   },


### PR DESCRIPTION
## Feature o Ticket

Jira Link: [PWS1-75](https://scrumlatamc.atlassian.net/browse/PWS1-75)

## Descripción

Breve descripción: Se agregó un padding en el span que contiene el título "¿Qué opina nuestra comunidad?" Para que se separe del componente de arriba y para que cuando se agranden las tarjetas, estas mismas no tapen el título. También uno en el section de "Somos una gran comunidad" para separar los componentes
Se cambió la información del documento "data.ts" que contenía datos de la comunidad para que quede acorde al Figma

Detalles:

Se agregó dentro del className del span en Reviews.tsx las líneas "pb-10 pt-14" para generar los espacios necesitados
Se agregó dentro del className del section en CounterToCommunity.tsx la línea "pb-16" para generar el espacio necesitado
Se editó dentro del archivo data.ts el array "counters". Los objetos ahora poseen los numeros asignados por el figma

## ¿Cómo se ha probado esto?

Se realizaron pruebas en las siguientes vistas para asegurar que los cambios funcionen correctamente:

Vista A: Desktop
- Test A1: Opera Pantalla de 1920 x 1080
- Test A1: Opera Pantalla de 1280 x 720

### Pasos para reproducir:

Desde la vista del inicio, scrollear hacia abajo hasta encontrar el título "¿Qué opina nuestra comunidad?".

### Notas adicionales:

Vista Mobile no funciona de momento, por lo que los cambios faltan por realizar
