### PR TITLE
Fix mobile Home (sponsors and flags)

### DIFF
--- a/src/app/home/components/FlagsCommunity.tsx
+++ b/src/app/home/components/FlagsCommunity.tsx
@@ -19,7 +19,7 @@ export const FlagsCommunity = () => {
   return (
     <div className='relative w-screen bg-black-5 py-6 shadow-shadowFlags md:m-auto md:max-w-screen-2xl md:py-[2.5%] md:shadow-shadowFlagsDesktop'>
       <div className='flex min-h-[5vh] overflow-hidden sm:h-12 md:bg-inherit'>
-        <div className='flex w-full animate-scrollLeft items-center justify-center xs:gap-4 sm:gap-4 lg:gap-20'>
+        <div className='flex w-full animate-scrollLeft items-center justify-center sm:gap-4 lg:gap-20'>
           {duplicateFlags.map((flag, index) => (
             <img
               alt={flag.name}

--- a/src/app/home/components/FlagsCommunity.tsx
+++ b/src/app/home/components/FlagsCommunity.tsx
@@ -17,14 +17,14 @@ export const FlagsCommunity = () => {
   const duplicateFlags = [...FlagsCommunity, ...FlagsCommunity]
 
   return (
-    <div className='relative max-w-screen-2xl shadow-shadowFlags md:m-auto md:py-[2.5%] md:shadow-shadowFlagsDesktop'>
-      <div className='flex min-h-[5vh] overflow-hidden bg-black-5 md:bg-inherit'>
-        <div className='flex w-full animate-scrollLeft items-center justify-center gap-[32px] md:gap-[96px]'>
+    <div className='relative max-w-screen-2xl bg-black-6 py-6 shadow-shadowFlags md:m-auto md:py-[2.5%] md:shadow-shadowFlagsDesktop'>
+      <div className='flex min-h-[5vh] overflow-hidden sm:h-12 md:bg-inherit'>
+        <div className='flex w-full animate-scrollLeft items-center justify-center xs:gap-4 sm:gap-4 lg:gap-20'>
           {duplicateFlags.map((flag, index) => (
             <img
               alt={flag.name}
               aria-hidden='true'
-              className='w-[24px] border-black-13 object-cover md:h-[3.6vw] md:w-widthFlags md:border 2xl:h-[90%]'
+              className='h-full w-[24px] w-widthFlags border border-black-13 object-cover'
               key={index}
               src={flag.flag}
             />

--- a/src/app/home/components/FlagsCommunity.tsx
+++ b/src/app/home/components/FlagsCommunity.tsx
@@ -17,9 +17,9 @@ export const FlagsCommunity = () => {
   const duplicateFlags = [...FlagsCommunity, ...FlagsCommunity]
 
   return (
-    <div className='relative w-screen bg-black-6 py-6 shadow-shadowFlags md:m-auto md:max-w-screen-2xl md:py-[2.5%] md:shadow-shadowFlagsDesktop'>
+    <div className='relative w-screen bg-black-5 py-6 shadow-shadowFlags md:m-auto md:max-w-screen-2xl md:py-[2.5%] md:shadow-shadowFlagsDesktop'>
       <div className='flex min-h-[5vh] overflow-hidden sm:h-12 md:bg-inherit'>
-        <div className='flex w-full animate-scrollLeft items-center justify-center xs:gap-4 sm:gap-4 lg:gap-20'>
+        <div className='xs:gap-4 flex w-full animate-scrollLeft items-center justify-center sm:gap-4 lg:gap-20'>
           {duplicateFlags.map((flag, index) => (
             <img
               alt={flag.name}

--- a/src/app/home/components/FlagsCommunity.tsx
+++ b/src/app/home/components/FlagsCommunity.tsx
@@ -19,7 +19,7 @@ export const FlagsCommunity = () => {
   return (
     <div className='relative w-screen bg-black-5 py-6 shadow-shadowFlags md:m-auto md:max-w-screen-2xl md:py-[2.5%] md:shadow-shadowFlagsDesktop'>
       <div className='flex min-h-[5vh] overflow-hidden sm:h-12 md:bg-inherit'>
-        <div className='xs:gap-4 flex w-full animate-scrollLeft items-center justify-center sm:gap-4 lg:gap-20'>
+        <div className='flex w-full animate-scrollLeft items-center justify-center xs:gap-4 sm:gap-4 lg:gap-20'>
           {duplicateFlags.map((flag, index) => (
             <img
               alt={flag.name}

--- a/src/app/home/components/FlagsCommunity.tsx
+++ b/src/app/home/components/FlagsCommunity.tsx
@@ -17,14 +17,14 @@ export const FlagsCommunity = () => {
   const duplicateFlags = [...FlagsCommunity, ...FlagsCommunity]
 
   return (
-    <div className='relative max-w-screen-2xl bg-black-6 py-6 shadow-shadowFlags md:m-auto md:py-[2.5%] md:shadow-shadowFlagsDesktop'>
+    <div className='relative w-screen bg-black-6 py-6 shadow-shadowFlags md:m-auto md:max-w-screen-2xl md:py-[2.5%] md:shadow-shadowFlagsDesktop'>
       <div className='flex min-h-[5vh] overflow-hidden sm:h-12 md:bg-inherit'>
         <div className='flex w-full animate-scrollLeft items-center justify-center xs:gap-4 sm:gap-4 lg:gap-20'>
           {duplicateFlags.map((flag, index) => (
             <img
               alt={flag.name}
               aria-hidden='true'
-              className='h-full w-[24px] w-widthFlags border border-black-13 object-cover'
+              className='h-full w-widthFlags border border-black-13 object-cover'
               key={index}
               src={flag.flag}
             />

--- a/src/app/home/components/Sponsors.tsx
+++ b/src/app/home/components/Sponsors.tsx
@@ -22,7 +22,7 @@ export const Sponsors: React.FC = () => {
         <span className='text-center font-darker-grotesque text-[20px] font-extrabold text-blue-6 sm:text-3xl md:text-5xl'>
           Junto a nuestros aliados
         </span>
-        <div className='flex w-full animate-scrollLeft items-center justify-center py-6 xs:gap-4 sm:gap-4 lg:gap-20'>
+        <div className='flex w-full animate-scrollLeft items-center justify-center py-6 sm:gap-4 lg:gap-20'>
           {duplicateSponsors.map((sponsors, index) => (
             <img
               alt={sponsors.name}

--- a/src/app/home/components/Sponsors.tsx
+++ b/src/app/home/components/Sponsors.tsx
@@ -18,16 +18,16 @@ export const Sponsors: React.FC = () => {
 
   return (
     <div className='flex flex-col items-center bg-black-4 px-4 py-6 text-white'>
-      <div className='flex w-full max-w-[960px] flex-col gap-4'>
+      <div className='flex max-w-[960px] flex-col'>
         <span className='text-center font-darker-grotesque text-[20px] font-extrabold text-blue-6 sm:text-3xl md:text-5xl'>
           Junto a nuestros aliados
         </span>
-        <div className='my-10 flex w-full animate-scrollLeft items-center justify-center gap-[32px] md:gap-[96px]'>
+        <div className='flex w-full animate-scrollLeft items-center justify-center py-6 xs:gap-4 sm:gap-4 lg:gap-20'>
           {duplicateSponsors.map((sponsors, index) => (
             <img
               alt={sponsors.name}
               aria-hidden='true'
-              className='w-widthFlags md:border 2xl:h-[90%]'
+              className='h-full w-[24px] w-widthFlags object-cover'
               key={index}
               src={sponsors.image}
             />

--- a/src/app/home/components/Sponsors.tsx
+++ b/src/app/home/components/Sponsors.tsx
@@ -17,7 +17,7 @@ export const Sponsors: React.FC = () => {
   const duplicateSponsors = [...SponsorsLogo, ...SponsorsLogo]
 
   return (
-    <div className='flex flex-col items-center bg-black-4 px-4 py-6 text-white'>
+    <div className='flex max-w-screen-2xl flex-col items-center overflow-hidden bg-black-4 px-4 py-6 text-white'>
       <div className='flex max-w-[960px] flex-col'>
         <span className='text-center font-darker-grotesque text-[20px] font-extrabold text-blue-6 sm:text-3xl md:text-5xl'>
           Junto a nuestros aliados
@@ -27,7 +27,7 @@ export const Sponsors: React.FC = () => {
             <img
               alt={sponsors.name}
               aria-hidden='true'
-              className='h-full w-[24px] w-widthFlags object-cover'
+              className='h-full w-widthFlags object-cover'
               key={index}
               src={sponsors.image}
             />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -106,6 +106,7 @@ const config: Config = {
         'darker-grotesque-11': global.fontWeights['darker-grotesque-11'].value, // Semi Bold
       },
       screens: {
+        xs: '320px',
         sm: '480px',
         md: '768px',
         lg: '1024px',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -106,7 +106,6 @@ const config: Config = {
         'darker-grotesque-11': global.fontWeights['darker-grotesque-11'].value, // Semi Bold
       },
       screens: {
-        xs: '320px',
         sm: '480px',
         md: '768px',
         lg: '1024px',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,8 +22,11 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "target": "ES2017"
   },
   "include": [
     "next-env.d.ts",
@@ -28,6 +35,11 @@
     "**/*.tsx",
     ".next/types/**/*.ts"
   ],
-  "typeRoots": ["./node_modules/@types", "types"],
-  "exclude": ["node_modules"]
+  "typeRoots": [
+    "./node_modules/@types",
+    "types"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Feature o Ticket

- Jira Link: []()

## Descripción

Correccion del error en vista mobile de la vista home, modificando los componentes flags y sponsors

Detalles:

- Se modifico el contenedor padre para que contenga sus hijos
- Se modifico el ancho de pantalla maximo tomado por la animacion
- Ambos cambios se realizaron en los componentes Flags y Sponsors

## ¿Cómo se ha probado esto?

Se realizaron pruebas en las siguientes vistas para asegurar que los cambios funcionen correctamente:

- Vista A: Vista mobile desplazada por ambos componentes
  - Test A1: Verificar los cambios realizados ajustados a la vista mobile
  - Test A2: Asegura que la vista ordenador no se modifique
- Vista B: Vista ordenador no puede tener desbordes
  - Test B1: Comprobar los componentes y los anchos de pantalla
  - Test B2: Asegura que las animaciones se cortan en el maximo tamaño de pantalla

### Pasos para reproducir:

1. Navegar a la vista Home.
2. Ver los limites de pantalla.
3. Verificar que no exista un desborde de pantalla.

Link QA: [aqui]()